### PR TITLE
Resolve environment build failures from metadata library version

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "St. Jude Cloud RNA-Seq V2 pipeline",
   "summary": "Align RNA-Seq to hg38",
   "dxapi": "1.0.0",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "developers": ["user-athrashe"],
   "authorizedUsers": [
       "user-appdpdnanexus_stjude.org",

--- a/src/stjude_rnaseqv2.sh
+++ b/src/stjude_rnaseqv2.sh
@@ -33,8 +33,8 @@ main() {
        conda install \
        -c conda-forge \
        -c bioconda \
-       miniwdl==0.7.5 \
-       docker-py==4.2.2 \
+       miniwdl==1.7.1 \
+       docker-py==6.0.0 \
        -y && \
        conda clean --all -y
  

--- a/src/stjude_rnaseqv2.sh
+++ b/src/stjude_rnaseqv2.sh
@@ -33,8 +33,9 @@ main() {
        conda install \
        -c conda-forge \
        -c bioconda \
-       miniwdl==1.7.1 \
-       docker-py==6.0.0 \
+       miniwdl==0.7.5 \
+       docker-py==4.2.2 \
+       importlib_metadata~=4.0 \
        -y && \
        conda clean --all -y
  


### PR DESCRIPTION
Zonggao from the clinical team reported issues running the pipeline. Upon investigation, the environment fails to build properly. Pinning an additional library